### PR TITLE
Fixes #2, Gfb.rename().

### DIFF
--- a/Test/test_boxfill_rename.py
+++ b/Test/test_boxfill_rename.py
@@ -1,0 +1,29 @@
+import vcs
+import cdms2
+
+# download sample data, if it isn't already there
+vcs.download_sample_data_files()
+
+# make a slab, make a boxfill, get default boxfill
+f = cdms2.open(vcs.sample_data + '/clt.nc')
+u = f('u')
+b = vcs.createboxfill()
+a = vcs.init()
+r = a.getboxfill()
+
+# rename() should rename the created boxfill
+b_name = b.name
+b.rename('foo')
+assert(b_name != b.name)
+
+# rename() should not rename the default object
+r.rename('bar')
+assert(r.name == 'default')
+
+# both 'foo' and 'bar' boxfills should be get-able
+a.getboxfill('foo')
+a.getboxfill('bar')
+
+# both boxfills should be plot-able
+a.boxfill(b,u)
+a.boxfill(r,u)

--- a/vcs/boxfill.py
+++ b/vcs/boxfill.py
@@ -368,7 +368,8 @@ class Gfb(object):
             warnings.warn(
                 "You were trying to rename the 'deafult' boxfill method, it was merely copied not renamed")
         else:
-            del(vcs.elements["boxfill"][self.name])
+            vcs.elements["boxfill"].pop(self.name)
+            self._name = newname
         self = vcs.elements["boxfill"][newname]
         return
 


### PR DESCRIPTION
@doutriaux1 Re-wrote to change ._name and pop old name from elements
if not 'default'. Preserves original objects.