### PR TITLE
BUG #26: If masking reduces the bounds of a dataset, plots look incom…

### DIFF
--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -59,6 +59,8 @@ class VTKVCSBackend(object):
             # the same as vcs.utils.getworldcoordinates for now. getworldcoordinates uses
             # gm.datawc_... or, if that is not set, it uses data axis margins (without bounds).
             'plotting_dataset_bounds',
+            # dataset bounds before masking
+            'vtk_dataset_bounds_no_mask',
             'renderer',
             'vtk_backend_grid',
             # vtkGeoTransform used for geographic transformation
@@ -596,8 +598,9 @@ class VTKVCSBackend(object):
             ren = kargs["renderer"]
 
         vtk_backend_grid = kargs.get("vtk_backend_grid", None)
+        vtk_dataset_bounds_no_mask = kargs.get("vtk_dataset_bounds_no_mask", None)
         vtk_backend_geo = kargs.get("vtk_backend_geo", None)
-        bounds = vtk_backend_grid.GetBounds() if vtk_backend_grid else None
+        bounds = vtk_dataset_bounds_no_mask if vtk_dataset_bounds_no_mask else None
 
         pipeline = vcsvtk.createPipeline(gm, self)
         if pipeline is not None:
@@ -802,11 +805,11 @@ class VTKVCSBackend(object):
 
         # Stippling
         vcs2vtk.stippleLine(line_prop, contLine.type[0])
-        vtk_backend_grid = kargs.get("vtk_backend_grid", None)
+        vtk_dataset_bounds_no_mask = kargs.get("vtk_dataset_bounds_no_mask", None)
         return self.fitToViewport(contActor,
                                   vp,
                                   wc=wc, geo=geo,
-                                  geoBounds=vtk_backend_grid.GetBounds(),
+                                  geoBounds=vtk_dataset_bounds_no_mask,
                                   priority=priority,
                                   create_renderer=True)
 

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -267,6 +267,8 @@ def removeHiddenPoints(grid):
                     if (vectorNorm < minVectorNorm):
                         minVector = vector
                         minVectorNorm = vectorNorm
+    hiddenScalars = False
+    hiddenVectors = False
     for i in range(pts.GetNumberOfPoints()):
         if (ghost.GetValue(i) & vtk.vtkDataSetAttributes.HIDDENPOINT):
             cells = vtk.vtkIdList()
@@ -277,9 +279,16 @@ def removeHiddenPoints(grid):
             # hidden points are not removed. This causes problems
             # because it changes the scalar range.
             if(scalars):
+                hiddenScalars = True
                 scalars.SetValue(i, minScalar)
             if(vectors):
+                hiddenVectors = True
                 vectors.SetTypedTuple(i, minVector)
+    # SetValue does not call modified - we'll have to call it after all calls.
+    if (hiddenScalars):
+        scalars.Modified()
+    if (hiddenVectors):
+        vectors.Modified()
     # ensure that GLOBALIDS are copied
     attributes = grid.GetCellData()
     attributes.SetActiveAttribute(-1, attributes.GLOBALIDS)

--- a/vcs/vcsvtk/boxfillpipeline.py
+++ b/vcs/vcsvtk/boxfillpipeline.py
@@ -119,7 +119,7 @@ class BoxfillPipeline(Pipeline2D):
             # (we need one for each mapper because of camera flips)
             dataset_renderer, xScale, yScale = self._context().fitToViewport(
                 act, vp,
-                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=(dataset_renderer is None))
@@ -130,7 +130,7 @@ class BoxfillPipeline(Pipeline2D):
                 # why so sticking to many mappers
                 self._context().fitToViewport(
                     act, vp,
-                    wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                    wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                     geo=self._vtkGeoTransform,
                     priority=self._template.data.priority,
                     create_renderer=True)
@@ -146,6 +146,7 @@ class BoxfillPipeline(Pipeline2D):
         kwargs = {"vtk_backend_grid": self._vtkDataSet,
                   "dataset_bounds": self._vtkDataSetBounds,
                   "plotting_dataset_bounds": plotting_dataset_bounds,
+                  "vtk_dataset_bounds_no_mask": self._vtkDataSetBoundsNoMask,
                   "vtk_backend_geo": self._vtkGeoTransform}
         if ("ratio_autot_viewport" in self._resultDict):
             kwargs["ratio_autot_viewport"] = vp
@@ -200,9 +201,7 @@ class BoxfillPipeline(Pipeline2D):
             continents_renderer, xScale, yScale = self._context().plotContinents(
                 plotting_dataset_bounds, projection,
                 self._dataWrapModulo,
-                vp, self._template.data.priority,
-                vtk_backend_grid=self._vtkDataSet,
-                dataset_bounds=self._vtkDataSetBounds)
+                vp, self._template.data.priority, **kwargs)
 
     def _plotInternalBoxfill(self):
         """Implements the logic to render a non-custom boxfill."""

--- a/vcs/vcsvtk/isofillpipeline.py
+++ b/vcs/vcsvtk/isofillpipeline.py
@@ -153,14 +153,14 @@ class IsofillPipeline(Pipeline2D):
             # (we need one for each mapper because of cmaera flips)
             dataset_renderer, xScale, yScale = self._context().fitToViewport(
                 act, vp,
-                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=(mapper is self._maskedDataMapper or dataset_renderer is None))
         for act in patternActors:
             self._context().fitToViewport(
                 act, vp,
-                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
@@ -176,6 +176,7 @@ class IsofillPipeline(Pipeline2D):
         kwargs = {"vtk_backend_grid": self._vtkDataSet,
                   "dataset_bounds": self._vtkDataSetBounds,
                   "plotting_dataset_bounds": plotting_dataset_bounds,
+                  "vtk_dataset_bounds_no_mask": self._vtkDataSetBoundsNoMask,
                   "vtk_backend_geo": self._vtkGeoTransform}
         if ("ratio_autot_viewport" in self._resultDict):
             kwargs["ratio_autot_viewport"] = vp
@@ -221,6 +222,4 @@ class IsofillPipeline(Pipeline2D):
             continents_renderer, xScale, yScale = self._context().plotContinents(
                 plotting_dataset_bounds, projection,
                 self._dataWrapModulo,
-                vp, self._template.data.priority,
-                vtk_backend_grid=self._vtkDataSet,
-                dataset_bounds=self._vtkDataSetBounds)
+                vp, self._template.data.priority, **kwargs)

--- a/vcs/vcsvtk/isolinepipeline.py
+++ b/vcs/vcsvtk/isolinepipeline.py
@@ -257,7 +257,7 @@ class IsolinePipeline(Pipeline2D):
             # (we need one for each mapper because of cmaera flips)
             dataset_renderer, xScale, yScale = self._context().fitToViewport(
                 act, vp,
-                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=(dataset_renderer is None))
@@ -283,7 +283,7 @@ class IsolinePipeline(Pipeline2D):
             # (we need one for each mapper because of cmaera flips)
             self._context().fitToViewport(
                 act, vp,
-                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
@@ -298,6 +298,7 @@ class IsolinePipeline(Pipeline2D):
         kwargs = {"vtk_backend_grid": self._vtkDataSet,
                   "dataset_bounds": self._vtkDataSetBounds,
                   "plotting_dataset_bounds": plotting_dataset_bounds,
+                  "vtk_dataset_bounds_no_mask": self._vtkDataSetBoundsNoMask,
                   "vtk_backend_geo": self._vtkGeoTransform}
         if ("ratio_autot_viewport" in self._resultDict):
             kwargs["ratio_autot_viewport"] = vp
@@ -313,6 +314,4 @@ class IsolinePipeline(Pipeline2D):
             continents_renderer, xScale, yScale = self._context().plotContinents(
                 plotting_dataset_bounds, projection,
                 self._dataWrapModulo,
-                vp, self._template.data.priority,
-                vtk_backend_grid=self._vtkDataSet,
-                dataset_bounds=self._vtkDataSetBounds)
+                vp, self._template.data.priority, **kwargs)

--- a/vcs/vcsvtk/meshfillpipeline.py
+++ b/vcs/vcsvtk/meshfillpipeline.py
@@ -185,7 +185,7 @@ class MeshfillPipeline(Pipeline2D):
             # (we need one for each mapper because of cmaera flips)
             dataset_renderer, xScale, yScale = self._context().fitToViewport(
                 act, vp,
-                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=(dataset_renderer is None))
@@ -195,7 +195,7 @@ class MeshfillPipeline(Pipeline2D):
                 # why so sticking to many mappers
                 self._context().fitToViewport(
                     act, vp,
-                    wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+                    wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
                     geo=self._vtkGeoTransform,
                     priority=self._template.data.priority,
                     create_renderer=True)
@@ -210,6 +210,7 @@ class MeshfillPipeline(Pipeline2D):
         kwargs = {"vtk_backend_grid": self._vtkDataSet,
                   "dataset_bounds": self._vtkDataSetBounds,
                   "plotting_dataset_bounds": plotting_dataset_bounds,
+                  "vtk_dataset_bounds_no_mask": self._vtkDataSetBoundsNoMask,
                   "vtk_backend_geo": self._vtkGeoTransform}
         if ("ratio_autot_viewport" in self._resultDict):
             kwargs["ratio_autot_viewport"] = vp
@@ -265,9 +266,7 @@ class MeshfillPipeline(Pipeline2D):
             continents_renderer, xScale, yScale = self._context().plotContinents(
                 plotting_dataset_bounds, projection,
                 self._dataWrapModulo,
-                vp, self._template.data.priority,
-                vtk_backend_grid=self._vtkDataSet,
-                dataset_bounds=self._vtkDataSetBounds)
+                vp, self._template.data.priority, **kwargs)
 
     def getPlottingBounds(self):
         """gm.datawc if it is set or dataset_bounds

--- a/vcs/vcsvtk/pipeline2d.py
+++ b/vcs/vcsvtk/pipeline2d.py
@@ -40,6 +40,10 @@ class IPipeline2D(Pipeline):
             pipeline.
         - _vtkDataSetBounds: The bounds of _vtkDataSet, in lon/lat space, as
             tuple(float xMin, float xMax, float yMin, float yMax)
+        - _vtkDataSetBoundsNoMask : The bounds of _vtkDataSet in Cartesian space
+            before masking. These are used instead of the dataset bounds
+            because masking can change the dataset bounds which results in a dataset
+            that looks incomplete.
         - _vtkPolyDataFilter: A vtkAlgorithm that produces a polydata
             representation of the data.
         - _colorMap: The vcs colormap object used to color the scalar data.
@@ -296,6 +300,7 @@ class Pipeline2D(IPipeline2D):
         self._updateContourLevelsAndColors()
 
         # Generate a mapper to render masked data:
+        self._vtkDataSetBoundsNoMask = self._vtkDataSet.GetBounds()
         self._createMaskedDataMapper()
 
         # Create the polydata filter:
@@ -367,7 +372,7 @@ class Pipeline2D(IPipeline2D):
         plotting_dataset_bounds = self.getPlottingBounds()
         surface_renderer, xScale, yScale = self._context().fitToViewport(
             act, vp,
-            wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
+            wc=plotting_dataset_bounds, geoBounds=self._vtkDataSetBoundsNoMask,
             geo=self._vtkGeoTransform,
             priority=self._template.data.priority,
             create_renderer=True)

--- a/vcs/vcsvtk/vectorpipeline.py
+++ b/vcs/vcsvtk/vectorpipeline.py
@@ -220,6 +220,7 @@ class VectorPipeline(Pipeline2D):
         kwargs = {'vtk_backend_grid': self._vtkDataSet,
                   'dataset_bounds': self._vtkDataSetBounds,
                   'plotting_dataset_bounds': plotting_dataset_bounds,
+                  "vtk_dataset_bounds_no_mask": self._vtkDataSetBoundsNoMask,
                   'vtk_backend_geo': self._vtkGeoTransform}
         if ('ratio_autot_viewport' in self._resultDict):
             kwargs["ratio_autot_viewport"] = vp
@@ -232,9 +233,7 @@ class VectorPipeline(Pipeline2D):
         if self._useContinents:
             continents_renderer, xScale, yScale = self._context().plotContinents(
                 plotting_dataset_bounds, projection,
-                self._dataWrapModulo, vp, self._template.data.priority,
-                vtk_backend_grid=self._vtkDataSet,
-                dataset_bounds=self._vtkDataSetBounds)
+                self._dataWrapModulo, vp, self._template.data.priority, **kwargs)
         self._resultDict["vtk_backend_actors"] = [[act, plotting_dataset_bounds]]
         self._resultDict["vtk_backend_glyphfilters"] = [glyphFilter]
         self._resultDict["vtk_backend_luts"] = [[None, None]]


### PR DESCRIPTION
…plete.

We use 'vtk_dataset_bounds_no_mask', the dataset bounds before masking
instead of the dataset bounds for fitToViewport.
