### PR TITLE
Patch for bug #136

### DIFF
--- a/vcs/utils.py
+++ b/vcs/utils.py
@@ -2237,7 +2237,10 @@ def creategraphicsmethod(gtype, gname='default', name=None):
         func = vcs.createisoline
     elif gtype in ['isofill', 'Gfi']:
         func = vcs.createisofill
-    elif gtype in ['boxfill', 'Gfb']:
+    elif gtype in ['boxfill', 'Gfb', 'default']:
+        # VCS uses a temporary graphics method type 'default' when the user
+        # doesn't specify a graphics method. This gets replaced later down the
+        # plotting pipeline, but is important for tracking tick information.
         func = vcs.createboxfill
     elif gtype in ['meshfill', 'Gfm']:
         func = vcs.createmeshfill


### PR DESCRIPTION
This patches over the bug documented in #136. The root of the problem, as I see it, is that VCS does some wonky stuff with graphics methods as part of the plot call. It attempts to create an invalid graphics method (of type `default`), which it then uses to track tickmark information. Once the arglist is passed into `canvas._reconstruct_tv`, the graphics method in the arglist is magically swapped out (by updating the list in place rather than by returning something) for an appropriate one if the graphics method type is "default" or "boxfill" with a name of "default". This new arglist is then passed to `VTKPlots`' plot method, where the proper graphics method is used. I'm still not entirely clear what happens with the tick information when this patch isn't in place; I'm guessing it never gets generated in the first place.

Weird.

Anyway, this should fix the bug.