### PR TITLE
if range of boxfill is too small eps needs to be float64 not float32

### DIFF
--- a/vcs/boxfill.py
+++ b/vcs/boxfill.py
@@ -929,6 +929,8 @@ class Gfb(object):
             high_end += .00001
             return [low_end, high_end]
         float_epsilon = numpy.finfo(numpy.float32).eps
+        if float_epsilon > (high_end-low_end):
+            float_epsilon = numpy.finfo(numpy.float64).eps
         contourLevels = numpy.arange(low_end, high_end + float_epsilon, dx)
 
         return contourLevels


### PR DESCRIPTION
fix #196
