### PR TITLE
BUG #195: Fix 1D plots slowdown.

### DIFF
--- a/vcs/vcsvtk/pipeline1d.py
+++ b/vcs/vcsvtk/pipeline1d.py
@@ -103,6 +103,7 @@ class Pipeline1D(Pipeline):
                 self._context().canvas.plot(m, donotstoredisplay=True)
 
         ren2 = self._context().createRenderer()
+        ren2.SetLayer(1)
         self._context().renWin.AddRenderer(ren2)
         tmpl.plot(self._context().canvas, data1, self._gm, bg=self._context().bg,
                   renderer=ren2, X=X, Y=Y)


### PR DESCRIPTION
1D plots slowdown because an extra renderer is added to the
render window at each iteration.