### PR TITLE
Resize

### DIFF
--- a/tests/test_vcs_png_window_resize.py
+++ b/tests/test_vcs_png_window_resize.py
@@ -5,6 +5,7 @@ import os
 class TestVCSPNG(basevcstest.VCSBaseTest):
     def __init__(self,*args,**kargs):
         kargs['bg']=0
+        kargs['geometry'] = {"width": 1200, "height": 790}
         super(TestVCSPNG,self).__init__(*args,**kargs)
 
     def testPngResizeWindow(self, *args, **kwargs):

--- a/tests/test_vcs_png_window_resize2.py
+++ b/tests/test_vcs_png_window_resize2.py
@@ -1,0 +1,18 @@
+import basevcstest
+import vcs
+import os
+
+class TestVCSPNG(basevcstest.VCSBaseTest):
+    def __init__(self,*args,**kargs):
+        kargs['bg']=0
+        kargs['geometry'] = {"width": 1200, "height": 790}
+        super(TestVCSPNG,self).__init__(*args,**kargs)
+
+    def testPngResizeWindow(self, *args, **kwargs):
+        self.x.plot([1,2,3,4,5,6,7])
+        fnm = os.path.splitext(__file__)[0] + "_.png"
+        self.x.png(fnm)
+        self.x.geometry(800,600)
+        fnm = os.path.splitext(__file__)[0] + ".png"
+        self.x.png(fnm)
+        self.checkImage(fnm,pngReady=True)

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -556,7 +556,7 @@ class VTKVCSBackend(object):
                 self._geometry["width"] = self.canvas.bgX
                 self._geometry["height"] = self.canvas.bgY
         else:
-            self.renWin.SetSize(W, H)
+            self.setsize(W, H)
             self.canvas.bgX = W
             self.canvas.bgY = H
 
@@ -569,7 +569,7 @@ class VTKVCSBackend(object):
     def initialSize(self, width=None, height=None):
         # Gets user physical screen dimensions
         if isinstance(width, int) and isinstance(height, int):
-            self.renWin.SetSize(width, height)
+            self.setsize(width, height)
             self._lastSize = (width, height)
             return
 
@@ -592,7 +592,7 @@ class VTKVCSBackend(object):
         # make the dimensions even for Macs
         bgX = _makeEven(bgX)
         bgY = _makeEven(bgY)
-        self.renWin.SetSize(bgX, bgY)
+        self.setsize(bgX, bgY)
         self.canvas.bgX = bgX
         self.canvas.bgY = bgY
         self._lastSize = (bgX, bgY)
@@ -626,9 +626,13 @@ class VTKVCSBackend(object):
         y = args[1]
 
         if self.renWin is not None:
-            self.renWin.SetSize(x, y)
+            self.setsize(x, y)
         self._geometry = {'width': x, 'height': y}
         self._lastSize = (x, y)
+
+    def setsize(self, x, y):
+        self.renWin.SetSize(x, y)
+        self.configureEvent(None, None)
 
     def flush(self):
         if self.renWin is not None:
@@ -646,7 +650,7 @@ class VTKVCSBackend(object):
         self.createRenWin(**kargs)
         if self.bg:
             self.renWin.SetOffScreenRendering(True)
-            self.renWin.SetSize(self.canvas.bgX, self.canvas.bgY)
+            self.setsize(self.canvas.bgX, self.canvas.bgY)
         self.cell_coordinates = kargs.get('cell_coordinates', None)
         self.canvas.initLogoDrawing()
         if gtype == "text":
@@ -1246,8 +1250,7 @@ x.geometry(1200,800)
                 # otherwise, canvas.bgX,canvas.bgY will win
                 self.canvas.bgX = width
                 self.canvas.bgY = height
-                self.renWin.SetSize(width, height)
-                self.configureEvent(None, None)
+                self.setsize(width, height)
             else:
                 user_dims = None
 
@@ -1275,8 +1278,7 @@ x.geometry(1200,800)
         writer.Write()
         if user_dims is not None:
             self.canvas.bgX, self.canvas.bgY, w, h = user_dims
-            self.renWin.SetSize(w, h)
-            self.configureEvent(None, None)
+            self.setsize(w, h)
             self.renWin.Render()
 
     def cgm(self, file):

--- a/vcs/VTKPlots.py
+++ b/vcs/VTKPlots.py
@@ -1260,9 +1260,8 @@ x.geometry(1200,800)
             imgfiltr.SetInputBufferTypeToRGBA()
 
         self.hideGUI()
-        imgfiltr.Update()
-        self.showGUI(render=False)
         self.renWin.Render()
+        self.showGUI(render=False)
 
         writer = vtk.vtkPNGWriter()
         compression = args.get('compression', 5)  # get compression from user
@@ -1278,6 +1277,7 @@ x.geometry(1200,800)
             self.canvas.bgX, self.canvas.bgY, w, h = user_dims
             self.renWin.SetSize(w, h)
             self.configureEvent(None, None)
+            self.renWin.Render()
 
     def cgm(self, file):
         if self.renWin is None:


### PR DESCRIPTION
Partially fixes https://github.com/UV-CDAT/vcs/issues/228
That is, if the plot does not autot resizing works correctly. With autot, the second png looses the autot look.
Needs https://github.com/UV-CDAT/uvcdat-testdata/pull/175