### PR TITLE
Do not mark attribute as VECTORS so that are not removed.

### DIFF
--- a/tests/test_vcs_vectors_warp.py
+++ b/tests/test_vcs_vectors_warp.py
@@ -1,0 +1,19 @@
+import basevcstest
+import cdms2
+import vcs
+import MV2
+
+
+class TestVCSVectorsMissing(basevcstest.VCSBaseTest):
+    def testVCSVectorMissing(self):
+        u = self.clt['u']
+        v = self.clt['v']
+
+        gm = self.x.createvector()
+        gm.datawc_x1 = -180
+        gm.datawc_x2 = 360
+        gm.scale = 8
+
+        self.x.plot(gm, u[::5, ::5], v[::5, ::5])
+        fnm = "test_vcs_vectors_warp.png"
+        self.checkImage(fnm)

--- a/vcs/vcs2vtk.py
+++ b/vcs/vcs2vtk.py
@@ -964,11 +964,21 @@ def doWrapData(data, wc, wrap=[0., 360], fastClip=True):
     surface.SetInputData(data)
     surface.Update()
     data = surface.GetOutput()
-
     bounds = data.GetBounds()
     # insure that GLOBALIDS are not removed by the append filter
     attributes = data.GetCellData()
-    attributes.SetActiveAttribute(-1, attributes.GLOBALIDS)
+    globalIds = attributes.GetGlobalIds()
+    globalIdsName = None
+    if (globalIds):
+        globalIdsName = globalIds.GetName()
+    attributes.SetActiveAttribute(-1, vtk.vtkDataSetAttributes.GLOBALIDS)
+    # insure that vtkTransformPolyData does not change the VECTORS attribute
+    pointAttributes = data.GetPointData()
+    vectors = pointAttributes.GetVectors()
+    vectorsName = None
+    if (vectors):
+        vectorsName = vectors.GetName()
+    pointAttributes.SetActiveAttribute(-1, vtk.vtkDataSetAttributes.VECTORS)
     xmn = min(wc[0], wc[1])
     xmx = max(wc[0], wc[1])
     if (numpy.allclose(xmn, 1.e20) or numpy.allclose(xmx, 1.e20)):
@@ -1061,13 +1071,18 @@ def doWrapData(data, wc, wrap=[0., 360], fastClip=True):
         clipper.SetClipFunction(clipBox)
     clipper.SetInputConnection(appendFilter.GetOutputPort())
     clipper.Update()
-    # set globalids attribute
-    attributes = clipper.GetOutput().GetCellData()
-    globalIdsIndex = vtk.mutable(-1)
-    attributes.GetArray("GlobalIds", globalIdsIndex)
-    attributes.SetActiveAttribute(globalIdsIndex, attributes.GLOBALIDS)
-
-    return clipper.GetOutput()
+    result = clipper.GetOutput()
+    if (globalIdsName):
+        attributes = result.GetCellData()
+        index = vtk.mutable(-1)
+        attributes.GetArray(globalIdsName, index)
+        attributes.SetActiveAttribute(index, vtk.vtkDataSetAttributes.GLOBALIDS)
+    if (vectorsName):
+        index = vtk.mutable(-1)
+        pointAttributes = result.GetPointData()
+        pointAttributes.GetArray(vectorsName, index)
+        pointAttributes.SetActiveAttribute(index, vtk.vtkDataSetAttributes.VECTORS)
+    return result
 
 
 # Wrap grid in interval minX, minX + 360


### PR DESCRIPTION
vtkTransformPolyData changes a VECTORS attribute from double to float
than vtkAppendPolyData removes that attribute because of non-matching
attributes (double and float).