### PR TITLE
Fix various issues with resizing plots

### DIFF
--- a/tests/basevcstest.py
+++ b/tests/basevcstest.py
@@ -65,8 +65,8 @@ class VCSBaseTest(unittest.TestCase):
         if not pngReady:
             self.x.png(
                 fnm,
-                width=self.x.bgX,
-                height=self.x.bgY,
+                width=self.x.width,
+                height=self.x.height,
                 units="pixels")
         ret = checkimage.check_result_image(fnm, src, threshold)
         self.assertEqual(ret, 0)

--- a/tests/test_vcs_configurator_click_marker.py
+++ b/tests/test_vcs_configurator_click_marker.py
@@ -3,8 +3,8 @@ import basevcstest
 
 class TestVSConfigurator(basevcstest.VCSBaseTest):
     def testClickMarker(self):
-        self.x.bgX = 800
-        self.x.bgY = 606
+        self.x.width = 800
+        self.x.height = 606
         m = self.x.createmarker()
         m.x = .1,
         m.y = .1,
@@ -21,7 +21,7 @@ class TestVSConfigurator(basevcstest.VCSBaseTest):
         # Make sure the displays are current
         c.update()
 
-        w, h = self.x.bgX, self.x.bgY
+        w, h = self.x.width, self.x.height
 
         # Retrieve the actor at the specified point
         actor = c.actor_at_point(.1 * w, .1 * h)

--- a/tests/test_vcs_configurator_click_text.py
+++ b/tests/test_vcs_configurator_click_text.py
@@ -4,8 +4,8 @@ import basevcstest
 class TestVSConfigurator(basevcstest.VCSBaseTest):
     def testConfiguratorClickTest(self):
 
-        self.x.bgX = 800
-        self.x.bgY = 606
+        self.x.width = 800
+        self.x.height = 606
         t = self.x.createtext()
         t.string = "test string"
         t.x = .1
@@ -23,7 +23,7 @@ class TestVSConfigurator(basevcstest.VCSBaseTest):
         # Make sure the displays are current
         c.update()
 
-        w, h = self.x.bgX, self.x.bgY
+        w, h = self.x.width, self.x.height
 
         # Retrieve the actor at the specified point
         actor = c.actor_at_point(.1 * w + 10, .1 * h + 5)

--- a/vcs/Canvas.py
+++ b/vcs/Canvas.py
@@ -357,8 +357,8 @@ class Canvas(vcs.bestMatch):
         'ParameterChanged',
         'colormap',
         'backgroundcolor',
-        'bgX',
-        'bgY',
+        'width',
+        'height',
         'display_names',
         '_dotdir',
         '_dotdirenv',
@@ -919,18 +919,21 @@ class Canvas(vcs.bestMatch):
                                                                             maxelements=2, ints=True)
             else:
                 raise ValueError("geometry should be list, tuple, or dict")
-            geometry = {"width": width, "height": height}
 
-        if geometry is not None and bg:
-            self.bgX = geometry["width"]
-            self.bgY = geometry["height"]
+            self.width = width
+            self.height = height
         else:
-            # default size for bg
-            self.bgX = 814
-            self.bgY = 606
+            w, h = 814, 606
+            if size is not None:
+                # What is the purpose of the 'size' argument?  Is it intended to forever
+                # constrain the aspect ratio of the plot?  What if size and geometry are
+                # both given, but are inconsistent?
+                w = h * size
+            self.width = w
+            self.height = h
 
         if backend == "vtk":
-            self.backend = VTKVCSBackend(self, geometry=geometry, bg=bg)
+            self.backend = VTKVCSBackend(self, bg=bg)
         elif isinstance(backend, vtk.vtkRenderWindow):
             self.backend = VTKVCSBackend(self, renWin=backend, bg=bg)
         else:
@@ -4963,8 +4966,8 @@ class Canvas(vcs.bestMatch):
             width, height, units)
 
         # in pixels?
-        self.bgX = W
-        self.bgY = H
+        self.width = W
+        self.height = H
         return
     # display ping
     setbgoutputdimensions.__doc__ = setbgoutputdimensions.__doc__ % (xmldocs.output_width, xmldocs.output_height,
@@ -5306,8 +5309,8 @@ class Canvas(vcs.bestMatch):
                         height = 8.5
                         width = self.size * height
             else:
-                width = self.bgX
-                height = self.bgY
+                width = self.width
+                height = self.height
         elif width is None:
             if self.size is None:
                 width = 1.2941176470588236 * height

--- a/vcs/VTKAnimate.py
+++ b/vcs/VTKAnimate.py
@@ -51,11 +51,11 @@ class VTKAnimationCreate(animate_helper.StoppableThread):
         self.controller = controller
         self.create_prefix()
         self.canvas = vcs.init()
-        self.canvas.bgX, self.canvas.bgY = controller.vcs_self.backend.renWin.GetSize()
+        self.canvas.width, self.canvas.height = controller.vcs_self.backend.renWin.GetSize()
         # Animation resizing is broken right now; this will give us some buffer
         # space to work with.
-        self.canvas.bgX *= 2
-        self.canvas.bgY *= 2
+        self.canvas.width *= 2
+        self.canvas.height *= 2
         self.controller.animation_created = True
         import atexit
         atexit.register(self.close)


### PR DESCRIPTION
This topic also gets rid of the Canvas bgX and bgY variables, so there is now just a single source of truth for the size of a plot.  It is stored in Canvas as 'width' and 'height', VTKVCSBackend no longer maintains its own separate notion of the size.