### PR TITLE
[WIP] painfully trying to plot isofill with gengrid

### DIFF
--- a/vcs/Canvas.py
+++ b/vcs/Canvas.py
@@ -2973,7 +2973,7 @@ class Canvas(vcs.bestMatch):
         if inGrid is not None and arglist[0] is not None and\
                 isinstance(arglist[0], cdms2.avariable.AbstractVariable) and\
                 not isinstance(arglist[0].getGrid(), cdms2.grid.AbstractRectGrid) and\
-                arglist[3] not in ["meshfill", ]:
+                arglist[3] not in ["meshfill", "isofill" ]:
             raise RuntimeError("You are attempting to plot unstructured grid" +
                                "with a method that is not meshfill")
         # preprocessing for extra keyword (at-plotting-time options)
@@ -3926,7 +3926,7 @@ class Canvas(vcs.bestMatch):
                     arglist[1].setAxis(i, axes_changed2[i])
             # Check to make sure that you have at least 2 dimensions for the follow graphics methods
             # Flipping the order to avoid the tv not exist problem
-            if (arglist[3] in ['boxfill', 'isofill', 'isoline', 'vector']) and (
+            if (arglist[3] in ['boxfill', 'isoline', 'vector']) and (
                     len(arglist[0].shape) < 2):
                 raise vcsError(
                     'Invalid number of dimensions for %s' %


### PR DESCRIPTION
@danlipsa @sankhesh @aashish24  I need some help here.

I'm trying to get isofill (then isoline) to plot a generic grid w/o vertices info. In "theory" it shouldbe doable since we use only pointdata for isofill. 

So far I create the unstructured grid and it appears I set the data on it, but the code complains there's no input data. 

Here's my script and I'm attaching the grids as well

```python
from __future__ import print_function
import vcs
import cdms2
import os
import numpy
import vtk

data = cdms2.open("/Users/doutriaux1/PeterC/ne30_TS.nc")("TS")
gridFile = cdms2.open("/Users/doutriaux1/PeterC/ne30np4_latlon.091226.nc")
lats = gridFile("lat").filled()
lons = gridFile("lon").filled()
ncols = len(lats)
latAxis = cdms2.auxcoord.TransientAuxAxis1D(lats)
lonAxis = cdms2.auxcoord.TransientAuxAxis1D(lons)
grid = cdms2.gengrid.TransientGenericGrid(latAxis,lonAxis) 
data.setAxis(-1,grid.getAxisList()[0])
data.setGrid(grid)
import vcs
x=vcs.init()
gm = vcs.createisofill()
x.plot(data,gm)
x.png("isof")
```

[grid.zip](https://github.com/UV-CDAT/vcs/files/1769266/grid.zip)
